### PR TITLE
links added as applicable

### DIFF
--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -1009,6 +1009,22 @@
                   complete course tutorial. ~ Leela Web Dev</a>
                 <span class="resource-link-badge">Video</span>
               </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://git-scm.com/">Website</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://git-scm.com/downloads">
+                  Download here
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://git-scm.com/book/en/v2">
+                  Documentation
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
             </ul>
           </div>
 
@@ -1061,6 +1077,24 @@
                   documentation</a>
                 <span class="resource-link-badge">Article</span>
               </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://github.com/">
+                  Website
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://desktop.github.com/">
+                  Download here
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://docs.github.com/en">
+                  Documentation
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
             </ul>
           </div>
 
@@ -1073,6 +1107,18 @@
                   GitLab tutorial. ~ GitSchoolDude</a>
                 <span class="resource-link-badge">Video</span>
               </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://about.gitlab.com/">
+                  Website
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://docs.gitlab.com/">
+                  Documentation
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
             </ul>
           </div>
 
@@ -1081,9 +1127,9 @@
             <h3 class="resource-card-title">BitBucket</h3>
             <ul class="resource-card-links">
               <li class="resource-link">
-                <a target="_blank" href="#"></a>
-              </li>
-              <span class="resource-link-badge"></span>
+                <a target="_blank" href="https://bitbucket.org/">Website</a>
+                <span class="resource-link-badge">Link</span>
+              </li> 
             </ul>
           </div>
         </div>

--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -1008,7 +1008,12 @@
                 <a target="_blank" href="https://git-scm.com/">Website</a>
                 <span class="resource-link-badge">Link</span>
               </li>
-              
+              <li class="resource-link">
+                <a target="_blank" href="https://git-scm.com/downloads">
+                  Download here
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
               <li class="resource-link">
                 <a target="_blank" href="https://git-scm.com/book/en/v2">
                   Documentation
@@ -1023,23 +1028,6 @@
             </ul>
           </div>
 
-          <!--* git desktop -->
-          <div id="git-desktop" class="resource-card">
-            <h3 class="resource-card-title">Git Desktop</h3>
-            <ul class="resource-card-links">
-              <li class="resource-link">
-                <a target="_blank" href="https://git-scm.com/downloads">
-                  Download here
-                </a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://youtu.be/GqNAD4XoZ6k">Using Git Desktop for beginners. ~ Kevin
-                  Powell</a>
-                <span class="resource-link-badge">Video</span>
-              </li>
-            </ul>
-          </div>
 
           <!--* github -->
           <div id="github" class="resource-card">
@@ -1065,6 +1053,11 @@
               </li>
               <li class="resource-link">
                 <a target="_blank" href="https://youtu.be/RGOj5yH7evk">Git and GitHub for beginners. ~ FreeCodeCamp</a>
+                <span class="resource-link-badge">Video</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://youtu.be/GqNAD4XoZ6k">Using Git Desktop for beginners. ~ Kevin
+                  Powell</a>
                 <span class="resource-link-badge">Video</span>
               </li>
               <li class="resource-link">

--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -1005,25 +1005,20 @@
             <h3 class="resource-card-title">Git</h3>
             <ul class="resource-card-links">
               <li class="resource-link">
-                <a target="_blank" href="https://youtube.com/playlist?list=PL_euSNU_eLbegnt7aR8I1gXfLhKZbxnYX">Git
-                  complete course tutorial. ~ Leela Web Dev</a>
-                <span class="resource-link-badge">Video</span>
-              </li>
-              <li class="resource-link">
                 <a target="_blank" href="https://git-scm.com/">Website</a>
                 <span class="resource-link-badge">Link</span>
               </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://git-scm.com/downloads">
-                  Download here
-                </a>
-                <span class="resource-link-badge">Link</span>
-              </li>
+              
               <li class="resource-link">
                 <a target="_blank" href="https://git-scm.com/book/en/v2">
                   Documentation
                 </a>
                 <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://youtube.com/playlist?list=PL_euSNU_eLbegnt7aR8I1gXfLhKZbxnYX">Git
+                  complete course tutorial. ~ Leela Web Dev</a>
+                <span class="resource-link-badge">Video</span>
               </li>
             </ul>
           </div>
@@ -1032,6 +1027,12 @@
           <div id="git-desktop" class="resource-card">
             <h3 class="resource-card-title">Git Desktop</h3>
             <ul class="resource-card-links">
+              <li class="resource-link">
+                <a target="_blank" href="https://git-scm.com/downloads">
+                  Download here
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
               <li class="resource-link">
                 <a target="_blank" href="https://youtu.be/GqNAD4XoZ6k">Using Git Desktop for beginners. ~ Kevin
                   Powell</a>
@@ -1044,6 +1045,24 @@
           <div id="github" class="resource-card">
             <h3 class="resource-card-title">GitHub</h3>
             <ul class="resource-card-links">
+              <li class="resource-link">
+                <a target="_blank" href="https://github.com/">
+                  Website
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://desktop.github.com/">
+                  Download here
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://docs.github.com/en">
+                  Documentation
+                </a>
+                <span class="resource-link-badge">Link</span>
+              </li>
               <li class="resource-link">
                 <a target="_blank" href="https://youtu.be/RGOj5yH7evk">Git and GitHub for beginners. ~ FreeCodeCamp</a>
                 <span class="resource-link-badge">Video</span>
@@ -1077,24 +1096,6 @@
                   documentation</a>
                 <span class="resource-link-badge">Article</span>
               </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://github.com/">
-                  Website
-                </a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://desktop.github.com/">
-                  Download here
-                </a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://docs.github.com/en">
-                  Documentation
-                </a>
-                <span class="resource-link-badge">Link</span>
-              </li>
             </ul>
           </div>
 
@@ -1102,11 +1103,6 @@
           <div id="gitlab" class="resource-card">
             <h3 class="resource-card-title">GitLab</h3>
             <ul class="resource-card-links">
-              <li class="resource-link">
-                <a target="_blank" href="https://youtube.com/playlist?list=PLu-nSsOS6FRIg52MWrd7C_qSnQp3ZoHwW">Git and
-                  GitLab tutorial. ~ GitSchoolDude</a>
-                <span class="resource-link-badge">Video</span>
-              </li>
               <li class="resource-link">
                 <a target="_blank" href="https://about.gitlab.com/">
                   Website
@@ -1118,6 +1114,11 @@
                   Documentation
                 </a>
                 <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://youtube.com/playlist?list=PLu-nSsOS6FRIg52MWrd7C_qSnQp3ZoHwW">Git and
+                  GitLab tutorial. ~ GitSchoolDude</a>
+                <span class="resource-link-badge">Video</span>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
I added the necessary links and also I noticed, what about git-desktop because both git and git-desktop have the same download source and if any further change requires then please tell me.
There are no separate docs and download links for BitBucket.
Here are the changes.