### PR TITLE
Adds AgnosticUI to list of CSS resources

### DIFF
--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -1483,7 +1483,7 @@
           </p>
           <p>
             Note: You do not need to learn all of them, you just have to know
-            atleast one CSS-only and one CSS-Js framework/library.
+            at least one CSS-only and one CSS-Js framework/library.
           </p>
           <p>
             Before picking your first framework/library, check these videos out;
@@ -1570,7 +1570,31 @@
               </li>
             </ul>
           </div>
+          <!--* AgnosticUI -->
+          <div id="bulma" class="resource-card">
+            <h3 class="resource-card-title">
+              AgnosticUI<span class="resource-link-badge">Css and Js</span>
+            </h3>
 
+            <ul class="resource-card-links">
+              <li class="resource-link">
+                <a target="_blank" href="https://www.agnosticui.com/">Website</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://github.com/AgnosticUI/AstroAgnosticUIStarter">Astro + AgnosticUI Starter</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://astro.build/themes/index.html">Astro Themes (allows you to preview)</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://developtodesign.com/agnosticui-examples">AgnosticUI Svelte Examples</a>
+                <span class="resource-link-badge">Playlist</span>
+              </li>
+            </ul>
+          </div>
           <!--* Bulma -->
           <div id="bulma" class="resource-card">
             <h3 class="resource-card-title">

--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -1570,31 +1570,6 @@
               </li>
             </ul>
           </div>
-          <!--* AgnosticUI -->
-          <div id="bulma" class="resource-card">
-            <h3 class="resource-card-title">
-              AgnosticUI<span class="resource-link-badge">Css and Js</span>
-            </h3>
-
-            <ul class="resource-card-links">
-              <li class="resource-link">
-                <a target="_blank" href="https://www.agnosticui.com/">Website</a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://github.com/AgnosticUI/AstroAgnosticUIStarter">Astro + AgnosticUI Starter</a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://astro.build/themes/index.html">Astro Themes (allows you to preview)</a>
-                <span class="resource-link-badge">Link</span>
-              </li>
-              <li class="resource-link">
-                <a target="_blank" href="https://developtodesign.com/agnosticui-examples">AgnosticUI Svelte Examples</a>
-                <span class="resource-link-badge">Playlist</span>
-              </li>
-            </ul>
-          </div>
           <!--* Bulma -->
           <div id="bulma" class="resource-card">
             <h3 class="resource-card-title">
@@ -2029,6 +2004,41 @@
                 <a target="_blank" href="https://youtu.be/s7bKr_-GLtM">Create admin dashboard using Angular. ~
                   Simplilearn</a>
                 <span class="resource-link-badge">Video</span>
+              </li>
+            </ul>
+          </div>
+          
+          <!--* AgnosticUI -->
+          <div id="agnosticui" class="resource-card">
+            <h3 class="resource-card-title">
+              AgnosticUI<span class="resource-link-badge"> is a UI component library that works in React, Vue 3, Svelte, and Angular.
+            </h3>
+            <p>Brand your UI components once with CSS Custom properties then use across several UI frameworks like React, Vue 3, or Svelte!</p>
+
+            <ul class="resource-card-links">
+              <li class="resource-link">
+                <a target="_blank" href="https://www.agnosticui.com/">Website</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://www.youtube.com/watch?v=sCLc2ttYJ2A">Intro to AgnosticUI</a>
+                <span class="resource-link-badge">Video</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://css-tricks.com/make-a-component-multiple-frameworks-in-a-monorepo/">How to Make a Component That Supports Multiple Frameworks</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://github.com/AgnosticUI/AstroAgnosticUIStarter">Astro + AgnosticUI Starter</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://astro.build/themes/index.html">Astro Themes (allows you to preview)</a>
+                <span class="resource-link-badge">Link</span>
+              </li>
+              <li class="resource-link">
+                <a target="_blank" href="https://developtodesign.com/agnosticui-examples">AgnosticUI Svelte Examples</a>
+                <span class="resource-link-badge">Link</span>
               </li>
             </ul>
           </div>

--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -2010,11 +2010,8 @@
           
           <!--* AgnosticUI -->
           <div id="agnosticui" class="resource-card">
-            <h3 class="resource-card-title">
-              AgnosticUI<span class="resource-link-badge"> is a UI component library that works in React, Vue 3, Svelte, and Angular.
-            </h3>
+            <h3 class="resource-card-title">AgnosticUI</h3>
             <p>Brand your UI components once with CSS Custom properties then use across several UI frameworks like React, Vue 3, or Svelte!</p>
-
             <ul class="resource-card-links">
               <li class="resource-link">
                 <a target="_blank" href="https://www.agnosticui.com/">Website</a>
@@ -2026,7 +2023,7 @@
               </li>
               <li class="resource-link">
                 <a target="_blank" href="https://css-tricks.com/make-a-component-multiple-frameworks-in-a-monorepo/">How to Make a Component That Supports Multiple Frameworks</a>
-                <span class="resource-link-badge">Link</span>
+                <span class="resource-link-badge">Article</span>
               </li>
               <li class="resource-link">
                 <a target="_blank" href="https://github.com/AgnosticUI/AstroAgnosticUIStarter">Astro + AgnosticUI Starter</a>

--- a/src/html/careers/frontend.html
+++ b/src/html/careers/frontend.html
@@ -282,6 +282,9 @@
               <li class="sidebar-subtitle">
                 <a href="#angular">Angular</a>
               </li>
+              <li class="sidebar-subtitle">
+                <a href="#agnosticui">AgnosticUI</a>
+              </li>
             </ul>
           </li>
 


### PR DESCRIPTION
This adds [AgnosticUI](https://agnosticui.com/) to the list. I think it might be interesting for folks that are interested in experimenting with multiple frameworks (React, Vue, Svelte) and/or using it with Astro which provides the means to combine UI frameworks on the same page with their Islands Architecture.