### PR TITLE
Change the color of footer links on hover from pink to grey

### DIFF
--- a/styles/Footer.module.scss
+++ b/styles/Footer.module.scss
@@ -16,7 +16,7 @@ $purple: hsl(271, 46%, 53%);
     color: $footer-color;
 
     &:hover {
-      color: hsl(350deg, 89%, 74%);
+      color: hsl(210, 28%, 86%);
     }
   }
 


### PR DESCRIPTION
#77 Changed the Footer links color when hovered 
from pink to greycolor: #d1dbe5 or hsl(210, 28%, 86%) 

Before
![image](https://user-images.githubusercontent.com/59964427/188312972-a917775f-b6d8-46aa-8c41-35122cd749b5.png)

After 
![image](https://user-images.githubusercontent.com/59964427/188312923-bfe8d05b-43f8-43c2-9627-75464575ce4a.png)
