### PR TITLE
Side menu in careers page close when the user clicks outside the menu

### DIFF
--- a/components/SideBar.js
+++ b/components/SideBar.js
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import styles from "../styles/SideBar.module.scss";
 import { FaArrowDown } from "react-icons/fa";
 
-const SideBar = ({ children, handleMenu, openMenu }) => {
+const SideBar = ({ children, handleMenu, openMenu }, menuRef) => {
   return (
-    <nav className={styles.sidebarNav}>
+    <nav className={styles.sidebarNav} ref={menuRef}>
       <div className={styles.sidebarWrapper}>
         {/* side bar toggle */}
         <div className={styles.sidebarToggle} onClick={handleMenu}>
@@ -21,4 +21,4 @@ const SideBar = ({ children, handleMenu, openMenu }) => {
   );
 };
 
-export default SideBar;
+export default forwardRef(SideBar);

--- a/pages/careers/backend.js
+++ b/pages/careers/backend.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import SideBar from "../../components/SideBar";
 import BackendNav from "../../components/backendPageContent/BackendNav";
 import Banner from "../../components/Banner";
@@ -25,6 +25,23 @@ const BackendPage = () => {
     "https://i.ibb.co/vYLYxmH/pankaj-patel-Ylk5n-nd9d-A-unsplash.jpg";
 
   const [openMenu, setOpenMenu] = useState(false);
+  const menuRef = useRef();
+
+  useEffect(() => {
+    const checkIfClickedOutside = (e) => {
+      // If the menu is open and the clicked target is not within the menu,
+      // then close the menu
+      if (openMenu && menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpenMenu(false);
+      }
+    };
+
+    document.addEventListener("mousedown", checkIfClickedOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", checkIfClickedOutside);
+    };
+  }, [openMenu]);
 
   const handleMenu = () => {
     setOpenMenu(!openMenu);
@@ -82,7 +99,7 @@ const BackendPage = () => {
           content="Free videos, articles, guides and other resources to help you become a backend developer."
         />
       </Head>
-      <SideBar handleMenu={handleMenu} openMenu={openMenu}>
+      <SideBar handleMenu={handleMenu} openMenu={openMenu} ref={menuRef}>
         <BackendNav handleMenu={handleMenu} openMenu={openMenu} />
       </SideBar>
       <Banner title={title} quote={quote} image={image} />

--- a/pages/careers/frontend.js
+++ b/pages/careers/frontend.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import SideBar from "../../components/SideBar";
 import FrontendNav from "../../components/frontendPageContent/FrontendNav";
 import Banner from "../../components/Banner";
@@ -32,6 +32,23 @@ const Frontend = () => {
     "https://i.ibb.co/vYLYxmH/pankaj-patel-Ylk5n-nd9d-A-unsplash.jpg";
 
   const [openMenu, setOpenMenu] = useState(false);
+  const menuRef = useRef();
+
+  useEffect(() => {
+    const checkIfClickedOutside = (e) => {
+      // If the menu is open and the clicked target is not within the menu,
+      // then close the menu
+      if (openMenu && menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpenMenu(false);
+      }
+    };
+
+    document.addEventListener("mousedown", checkIfClickedOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", checkIfClickedOutside);
+    };
+  }, [openMenu]);
 
   const handleMenu = () => {
     setOpenMenu(!openMenu);
@@ -85,7 +102,7 @@ const Frontend = () => {
           content="Free videos, articles, guides and other resources to help you become a frontend developer."
         />
       </Head>
-      <SideBar handleMenu={handleMenu} openMenu={openMenu}>
+      <SideBar handleMenu={handleMenu} openMenu={openMenu} ref={menuRef}>
         <FrontendNav handleMenu={handleMenu} openMenu={openMenu} />
       </SideBar>
       <Banner title={title} quote={quote} image={image} />


### PR DESCRIPTION
If the menu is open and the clicked target is not within the menu, menu will be closed.

This pull request is in regards to Issue #78 